### PR TITLE
Fixed #83: Add menu actions to main window.

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -160,6 +160,7 @@ void MainWindow::setup_ActionsMenu_Actions()
     Properties::Instance()->actions[CLEAR_TERMINAL]->setShortcut(seq);
     connect(Properties::Instance()->actions[CLEAR_TERMINAL], SIGNAL(triggered()), consoleTabulator, SLOT(clearActiveTerminal()));
     menu_Actions->addAction(Properties::Instance()->actions[CLEAR_TERMINAL]);
+    addAction(Properties::Instance()->actions[CLEAR_TERMINAL]);
 
     menu_Actions->addSeparator();
 
@@ -168,24 +169,28 @@ void MainWindow::setup_ActionsMenu_Actions()
     Properties::Instance()->actions[TAB_NEXT]->setShortcut(seq);
     connect(Properties::Instance()->actions[TAB_NEXT], SIGNAL(triggered()), consoleTabulator, SLOT(switchToRight()));
     menu_Actions->addAction(Properties::Instance()->actions[TAB_NEXT]);
+    addAction(Properties::Instance()->actions[TAB_NEXT]);
 
     Properties::Instance()->actions[TAB_PREV] = new QAction(QIcon::fromTheme("go-previous"), tr("Previous Tab"), this);
     seq = QKeySequence::fromString( settings.value(TAB_PREV, TAB_PREV_SHORTCUT).toString() );
     Properties::Instance()->actions[TAB_PREV]->setShortcut(seq);
     connect(Properties::Instance()->actions[TAB_PREV], SIGNAL(triggered()), consoleTabulator, SLOT(switchToLeft()));
     menu_Actions->addAction(Properties::Instance()->actions[TAB_PREV]);
+    addAction(Properties::Instance()->actions[TAB_PREV]);
 
     Properties::Instance()->actions[MOVE_LEFT] = new QAction(tr("Move Tab Left"), this);
     seq = QKeySequence::fromString( settings.value(MOVE_LEFT, MOVE_LEFT_SHORTCUT).toString() );
     Properties::Instance()->actions[MOVE_LEFT]->setShortcut(seq);
     connect(Properties::Instance()->actions[MOVE_LEFT], SIGNAL(triggered()), consoleTabulator, SLOT(moveLeft()));
     menu_Actions->addAction(Properties::Instance()->actions[MOVE_LEFT]);
+    addAction(Properties::Instance()->actions[MOVE_LEFT]);
 
     Properties::Instance()->actions[MOVE_RIGHT] = new QAction(tr("Move Tab Right"), this);
     seq = QKeySequence::fromString( settings.value(MOVE_RIGHT, MOVE_RIGHT_SHORTCUT).toString() );
     Properties::Instance()->actions[MOVE_RIGHT]->setShortcut(seq);
     connect(Properties::Instance()->actions[MOVE_RIGHT], SIGNAL(triggered()), consoleTabulator, SLOT(moveRight()));
     menu_Actions->addAction(Properties::Instance()->actions[MOVE_RIGHT]);
+    addAction(Properties::Instance()->actions[MOVE_RIGHT]);
 
     menu_Actions->addSeparator();
 
@@ -194,30 +199,35 @@ void MainWindow::setup_ActionsMenu_Actions()
     Properties::Instance()->actions[SPLIT_HORIZONTAL]->setShortcut(seq);
     connect(Properties::Instance()->actions[SPLIT_HORIZONTAL], SIGNAL(triggered()), consoleTabulator, SLOT(splitHorizontally()));
     menu_Actions->addAction(Properties::Instance()->actions[SPLIT_HORIZONTAL]);
+    addAction(Properties::Instance()->actions[SPLIT_HORIZONTAL]);
 
     Properties::Instance()->actions[SPLIT_VERTICAL] = new QAction(tr("Split Terminal Vertically"), this);
     seq = QKeySequence::fromString( settings.value(SPLIT_VERTICAL).toString() );
     Properties::Instance()->actions[SPLIT_VERTICAL]->setShortcut(seq);
     connect(Properties::Instance()->actions[SPLIT_VERTICAL], SIGNAL(triggered()), consoleTabulator, SLOT(splitVertically()));
     menu_Actions->addAction(Properties::Instance()->actions[SPLIT_VERTICAL]);
+    addAction(Properties::Instance()->actions[SPLIT_VERTICAL]);
 
     Properties::Instance()->actions[SUB_COLLAPSE] = new QAction(tr("Collapse Subterminal"), this);
     seq = QKeySequence::fromString( settings.value(SUB_COLLAPSE).toString() );
     Properties::Instance()->actions[SUB_COLLAPSE]->setShortcut(seq);
     connect(Properties::Instance()->actions[SUB_COLLAPSE], SIGNAL(triggered()), consoleTabulator, SLOT(splitCollapse()));
     menu_Actions->addAction(Properties::Instance()->actions[SUB_COLLAPSE]);
+    addAction(Properties::Instance()->actions[SUB_COLLAPSE]);
 
     Properties::Instance()->actions[SUB_NEXT] = new QAction(QIcon::fromTheme("go-up"), tr("Next Subterminal"), this);
     seq = QKeySequence::fromString( settings.value(SUB_NEXT, SUB_NEXT_SHORTCUT).toString() );
     Properties::Instance()->actions[SUB_NEXT]->setShortcut(seq);
     connect(Properties::Instance()->actions[SUB_NEXT], SIGNAL(triggered()), consoleTabulator, SLOT(switchNextSubterminal()));
     menu_Actions->addAction(Properties::Instance()->actions[SUB_NEXT]);
+    addAction(Properties::Instance()->actions[SUB_NEXT]);
 
     Properties::Instance()->actions[SUB_PREV] = new QAction(QIcon::fromTheme("go-down"), tr("Previous Subterminal"), this);
     seq = QKeySequence::fromString( settings.value(SUB_PREV, SUB_PREV_SHORTCUT).toString() );
     Properties::Instance()->actions[SUB_PREV]->setShortcut(seq);
     connect(Properties::Instance()->actions[SUB_PREV], SIGNAL(triggered()), consoleTabulator, SLOT(switchPrevSubterminal()));
     menu_Actions->addAction(Properties::Instance()->actions[SUB_PREV]);
+    addAction(Properties::Instance()->actions[SUB_PREV]);
 
     menu_Actions->addSeparator();
 
@@ -227,36 +237,42 @@ void MainWindow::setup_ActionsMenu_Actions()
     Properties::Instance()->actions[COPY_SELECTION]->setShortcut(seq);
     connect(Properties::Instance()->actions[COPY_SELECTION], SIGNAL(triggered()), consoleTabulator, SLOT(copySelection()));
     menu_Edit->addAction(Properties::Instance()->actions[COPY_SELECTION]);
+    addAction(Properties::Instance()->actions[COPY_SELECTION]);
 
     Properties::Instance()->actions[PASTE_CLIPBOARD] = new QAction(QIcon::fromTheme("edit-paste"), tr("Paste Clipboard"), this);
     seq = QKeySequence::fromString( settings.value(PASTE_CLIPBOARD, PASTE_CLIPBOARD_SHORTCUT).toString() );
     Properties::Instance()->actions[PASTE_CLIPBOARD]->setShortcut(seq);
     connect(Properties::Instance()->actions[PASTE_CLIPBOARD], SIGNAL(triggered()), consoleTabulator, SLOT(pasteClipboard()));
     menu_Edit->addAction(Properties::Instance()->actions[PASTE_CLIPBOARD]);
+    addAction(Properties::Instance()->actions[PASTE_CLIPBOARD]);
 
     Properties::Instance()->actions[PASTE_SELECTION] = new QAction(QIcon::fromTheme("edit-paste"), tr("Paste Selection"), this);
     seq = QKeySequence::fromString( settings.value(PASTE_SELECTION, PASTE_SELECTION_SHORTCUT).toString() );
     Properties::Instance()->actions[PASTE_SELECTION]->setShortcut(seq);
     connect(Properties::Instance()->actions[PASTE_SELECTION], SIGNAL(triggered()), consoleTabulator, SLOT(pasteSelection()));
     menu_Edit->addAction(Properties::Instance()->actions[PASTE_SELECTION]);
+    addAction(Properties::Instance()->actions[PASTE_SELECTION]);
 
     Properties::Instance()->actions[ZOOM_IN] = new QAction(QIcon::fromTheme("zoom-in"), tr("Zoom in"), this);
     seq = QKeySequence::fromString( settings.value(ZOOM_IN, ZOOM_IN_SHORTCUT).toString() );
     Properties::Instance()->actions[ZOOM_IN]->setShortcut(seq);
     connect(Properties::Instance()->actions[ZOOM_IN], SIGNAL(triggered()), consoleTabulator, SLOT(zoomIn()));
     menu_Edit->addAction(Properties::Instance()->actions[ZOOM_IN]);
+    addAction(Properties::Instance()->actions[ZOOM_IN]);
 
     Properties::Instance()->actions[ZOOM_OUT] = new QAction(QIcon::fromTheme("zoom-out"), tr("Zoom out"), this);
     seq = QKeySequence::fromString( settings.value(ZOOM_OUT, ZOOM_OUT_SHORTCUT).toString() );
     Properties::Instance()->actions[ZOOM_OUT]->setShortcut(seq);
     connect(Properties::Instance()->actions[ZOOM_OUT], SIGNAL(triggered()), consoleTabulator, SLOT(zoomOut()));
     menu_Edit->addAction(Properties::Instance()->actions[ZOOM_OUT]);
+    addAction(Properties::Instance()->actions[ZOOM_OUT]);
 
     Properties::Instance()->actions[ZOOM_RESET] = new QAction(QIcon::fromTheme("zoom-original"), tr("Zoom reset"), this);
     seq = QKeySequence::fromString( settings.value(ZOOM_RESET, ZOOM_RESET_SHORTCUT).toString() );
     Properties::Instance()->actions[ZOOM_RESET]->setShortcut(seq);
     connect(Properties::Instance()->actions[ZOOM_RESET], SIGNAL(triggered()), consoleTabulator, SLOT(zoomReset()));
     menu_Edit->addAction(Properties::Instance()->actions[ZOOM_RESET]);
+    addAction(Properties::Instance()->actions[ZOOM_RESET]);
 
     menu_Actions->addSeparator();
 
@@ -265,6 +281,7 @@ void MainWindow::setup_ActionsMenu_Actions()
     Properties::Instance()->actions[FIND]->setShortcut(seq);
     connect(Properties::Instance()->actions[FIND], SIGNAL(triggered()), this, SLOT(find()));
     menu_Actions->addAction(Properties::Instance()->actions[FIND]);
+    addAction(Properties::Instance()->actions[FIND]);
 
 #if 0
     act = new QAction(this);
@@ -288,6 +305,7 @@ void MainWindow::setup_ActionsMenu_Actions()
     seq = QKeySequence::fromString( settings.value(TOGGLE_MENU, TOGGLE_MENU_SHORTCUT).toString() );
     Properties::Instance()->actions[TOGGLE_MENU]->setShortcut(seq);
     connect(Properties::Instance()->actions[TOGGLE_MENU], SIGNAL(triggered()), this, SLOT(toggleMenu()));
+    addAction(Properties::Instance()->actions[TOGGLE_MENU]);
     // tis is correct - add action to main window - not to menu to keep toggle working
 
     settings.endGroup();
@@ -307,6 +325,7 @@ void MainWindow::setup_FileMenu_Actions()
     Properties::Instance()->actions[ADD_TAB]->setShortcut(seq);
     connect(Properties::Instance()->actions[ADD_TAB], SIGNAL(triggered()), this, SLOT(addNewTab()));
     menu_File->addAction(Properties::Instance()->actions[ADD_TAB]);
+    addAction(Properties::Instance()->actions[ADD_TAB]);
 
     QMenu *presetsMenu = new QMenu(tr("New Tab From Preset"), this);
     presetsMenu->addAction(QIcon(), tr("1 Terminal"),
@@ -324,24 +343,28 @@ void MainWindow::setup_FileMenu_Actions()
     Properties::Instance()->actions[CLOSE_TAB]->setShortcut(seq);
     connect(Properties::Instance()->actions[CLOSE_TAB], SIGNAL(triggered()), consoleTabulator, SLOT(removeCurrentTab()));
     menu_File->addAction(Properties::Instance()->actions[CLOSE_TAB]);
+    addAction(Properties::Instance()->actions[CLOSE_TAB]);
 
     Properties::Instance()->actions[NEW_WINDOW] = new QAction(QIcon::fromTheme("window-new"), tr("New Window"), this);
     seq = QKeySequence::fromString( settings.value(NEW_WINDOW, NEW_WINDOW_SHORTCUT).toString() );
     Properties::Instance()->actions[NEW_WINDOW]->setShortcut(seq);
     connect(Properties::Instance()->actions[NEW_WINDOW], SIGNAL(triggered()), this, SLOT(newTerminalWindow()));
     menu_File->addAction(Properties::Instance()->actions[NEW_WINDOW]);
+    addAction(Properties::Instance()->actions[NEW_WINDOW]);
 
     menu_File->addSeparator();
 
     Properties::Instance()->actions[PREFERENCES] = actProperties;
     connect(actProperties, SIGNAL(triggered()), SLOT(actProperties_triggered()));
     menu_File->addAction(Properties::Instance()->actions[PREFERENCES]);
+    addAction(Properties::Instance()->actions[PREFERENCES]);
 
     menu_File->addSeparator();
 
     Properties::Instance()->actions[QUIT] = actQuit;
     connect(actQuit, SIGNAL(triggered()), SLOT(close()));
     menu_File->addAction(Properties::Instance()->actions[QUIT]);
+    addAction(Properties::Instance()->actions[QUIT]);
 
     settings.endGroup();
 }


### PR DESCRIPTION
Actions can only be triggered by shortcuts if the widget they belong to is visible. So the shortcuts to menu actions didn't work when the menu was hidden. The "Toggle Menu" shortcut didn't work at all.

I added the menu actions to the main window itself which is always visible.