### PR TITLE
Add fullscreen mode.

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -60,6 +60,7 @@
 
 #define HIDE_WINDOW_BORDERS "Hide Window Borders"
 #define SHOW_TAB_BAR "Show Tab Bar"
+#define FULLSCREEN "Fullscreen"
 
 /* Some defaults for QTerminal application */
 
@@ -104,6 +105,8 @@
 #define MOVE_RIGHT_SHORTCUT            "Shift+Alt+Right"
 
 #define RENAME_SESSION_SHORTCUT        "Shift+Alt+S"
+
+#define FULLSCREEN_SHORTCUT           "F11"
 
 // XON/XOFF features:
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -386,6 +386,7 @@ void MainWindow::setup_ViewMenu_Actions()
     hideBordersAction->setShortcut(seq);
     connect(hideBordersAction, SIGNAL(triggered()), this, SLOT(toggleBorderless()));
     menu_Window->addAction(hideBordersAction);
+    addAction(hideBordersAction);
     Properties::Instance()->actions[HIDE_WINDOW_BORDERS] = hideBordersAction;
     //Properties::Instance()->actions[HIDE_WINDOW_BORDERS]->setObjectName("toggle_Borderless");
 // TODO/FIXME: it's broken somehow. When I call toggleBorderless() here the non-responsive window appear
@@ -400,6 +401,7 @@ void MainWindow::setup_ViewMenu_Actions()
     seq = QKeySequence::fromString( settings.value(SHOW_TAB_BAR).toString() );
     showTabBarAction->setShortcut(seq);
     menu_Window->addAction(showTabBarAction);
+    addAction(showTabBarAction);
     Properties::Instance()->actions[SHOW_TAB_BAR] = showTabBarAction;
     toggleTabBar();
     connect(showTabBarAction, SIGNAL(triggered()), this, SLOT(toggleTabBar()));
@@ -410,6 +412,7 @@ void MainWindow::setup_ViewMenu_Actions()
     seq = QKeySequence::fromString(settings.value(FULLSCREEN, FULLSCREEN_SHORTCUT).toString());
     toggleFullscreen->setShortcut(seq);
     menu_Window->addAction(toggleFullscreen);
+    addAction(toggleFullscreen);
     connect(toggleFullscreen, SIGNAL(triggered(bool)), this, SLOT(showFullscreen(bool)));
     Properties::Instance()->actions[FULLSCREEN] = toggleFullscreen;
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -404,6 +404,15 @@ void MainWindow::setup_ViewMenu_Actions()
     toggleTabBar();
     connect(showTabBarAction, SIGNAL(triggered()), this, SLOT(toggleTabBar()));
 
+    QAction *toggleFullscreen = new QAction(tr("Fullscreen"), this);
+    toggleFullscreen->setCheckable(true);
+    toggleFullscreen->setChecked(false);
+    seq = QKeySequence::fromString(settings.value(FULLSCREEN, FULLSCREEN_SHORTCUT).toString());
+    toggleFullscreen->setShortcut(seq);
+    menu_Window->addAction(toggleFullscreen);
+    connect(toggleFullscreen, SIGNAL(triggered(bool)), this, SLOT(showFullscreen(bool)));
+    Properties::Instance()->actions[FULLSCREEN] = toggleFullscreen;
+
     Properties::Instance()->actions[TOGGLE_BOOKMARKS] = m_bookmarksDock->toggleViewAction();
     seq = QKeySequence::fromString( settings.value(TOGGLE_BOOKMARKS, TOGGLE_BOOKMARKS_SHORTCUT).toString() );
     Properties::Instance()->actions[TOGGLE_BOOKMARKS]->setShortcut(seq);
@@ -498,6 +507,14 @@ void MainWindow::toggleMenu()
 {
     m_menuBar->setVisible(!m_menuBar->isVisible());
     Properties::Instance()->menuVisible = m_menuBar->isVisible();
+}
+
+void MainWindow::showFullscreen(bool fullscreen)
+{
+    if(fullscreen)
+        setWindowState(windowState() | Qt::WindowFullScreen);
+    else
+        setWindowState(windowState() & ~Qt::WindowFullScreen);
 }
 
 void MainWindow::closeEvent(QCloseEvent *ev)

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -80,6 +80,7 @@ private slots:
     void toggleTabBar();
     void toggleMenu();
 
+    void showFullscreen(bool fullscreen);
     void showHide();
     void setKeepOpen(bool value);
     void find();


### PR DESCRIPTION
I really miss a fullscreen mode in QTerminal. When working in the terminal I sometimes like to disable all window decorations, menu bars, tab bars, etc. and make it fullscreen so that the black terminal window occupies the whole screen.

On the otherhand I don't really know, if there is a use case for the "Hide Window Borders" option. So is it maybe needless when we have a fullscreen mode?
What do you think?