### PR TITLE
Add instructions to disable system qxt when building with Qt5.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules")
 
 if(USE_QT5 AND USE_SYSTEM_QXT)
-    message(FATAL_ERROR "Unable to use system qxt with qt5 now")
+    message(FATAL_ERROR "Unable to use system qxt with qt5. Please use -DUSE_SYSTEM_QXT=false.")
 endif()
 
 if(USE_QT5)

--- a/INSTALL
+++ b/INSTALL
@@ -8,7 +8,7 @@ Build:
     http://www.cmake.org/Wiki/CMake_FAQ#Out-of-source_build_trees
 
     1) mkdir -p build && cd build
-    2a) cmake path/to/source -DUSE_QT5=true  # Qt 5
+    2a) cmake path/to/source -DUSE_QT5=true  -DUSE_SYSTEM_QXT=false # Qt 5
     2b) cmake path/to/source  # Qt 4 only
     3) make
     4) optional: make install


### PR DESCRIPTION
I struggled with it when I build QTerminal for the first time and someone in IRC mentioned it, too.