### PR TITLE
Rename AlwaysShowTabs setting and keep version number in settings up-to-date.

### DIFF
--- a/src/forms/propertiesdialog.ui
+++ b/src/forms/propertiesdialog.ui
@@ -132,9 +132,9 @@
         </widget>
        </item>
        <item row="7" column="0">
-        <widget class="QCheckBox" name="alwaysShowTabsCheckBox">
+        <widget class="QCheckBox" name="hideTabBarCheckBox">
          <property name="text">
-          <string>Always show the tab bar</string>
+          <string>Hide tab bar with only one tab</string>
          </property>
         </widget>
        </item>

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -104,19 +104,24 @@ void MainWindow::migrate_settings()
     // If this method becomes unbearably huge we should look at the config-update
     // system used by kde and razor.
     QSettings settings;
-    QString last_version = settings.value("version", "0.0.0").toString();
-    // Handle configchanges in 0.4.0 (renaming 'Paste Selection' -> 'Paste Clipboard')
-    if (last_version < "0.4.0")
+    QString lastVersion = settings.value("version", "0.0.0").toString();
+    QString currentVersion = STR_VERSION;
+    if (currentVersion < lastVersion)
     {
-        qDebug() << "Migrating settings from" << last_version << "to 0.4.0";
+        qDebug() << "Warning: Configuration file was written by a newer version "
+                 << "of QTerminal. Some settings might be incompatible";
+    }
+    // Handle renaming of 'Paste Selection' to 'Paste Clipboard' in 0.4.0
+    if (lastVersion < "0.4.0")
+    {
         settings.beginGroup("Shortcuts");
         QString tmp = settings.value("Paste Selection", PASTE_CLIPBOARD_SHORTCUT).toString();
         settings.setValue(PASTE_CLIPBOARD, tmp);
         settings.remove("Paste Selection");
         settings.endGroup();
-
-        settings.setValue("version", "0.4.0");
     }
+    if (currentVersion > lastVersion)
+        settings.setValue("version", currentVersion);
 }
 
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -47,8 +47,8 @@ MainWindow::MainWindow(const QString& work_dir,
       m_dropMode(dropMode)
 {
     setupUi(this);
+    Properties::Instance()->migrate_settings();
     Properties::Instance()->loadSettings();
-    migrate_settings();
 
     m_bookmarksDock = new QDockWidget(tr("Bookmarks"), this);
     m_bookmarksDock->setObjectName("BookmarksDockWidget");
@@ -97,33 +97,6 @@ MainWindow::MainWindow(const QString& work_dir,
 MainWindow::~MainWindow()
 {
 }
-
-void MainWindow::migrate_settings()
-{
-    // Deal with rearrangements of settings.
-    // If this method becomes unbearably huge we should look at the config-update
-    // system used by kde and razor.
-    QSettings settings;
-    QString lastVersion = settings.value("version", "0.0.0").toString();
-    QString currentVersion = STR_VERSION;
-    if (currentVersion < lastVersion)
-    {
-        qDebug() << "Warning: Configuration file was written by a newer version "
-                 << "of QTerminal. Some settings might be incompatible";
-    }
-    // Handle renaming of 'Paste Selection' to 'Paste Clipboard' in 0.4.0
-    if (lastVersion < "0.4.0")
-    {
-        settings.beginGroup("Shortcuts");
-        QString tmp = settings.value("Paste Selection", PASTE_CLIPBOARD_SHORTCUT).toString();
-        settings.setValue(PASTE_CLIPBOARD, tmp);
-        settings.remove("Paste Selection");
-        settings.endGroup();
-    }
-    if (currentVersion > lastVersion)
-        settings.setValue("version", currentVersion);
-}
-
 
 void MainWindow::enableDropMode()
 {

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -54,8 +54,6 @@ private:
 
     QDockWidget *m_bookmarksDock;
 
-    void migrate_settings();
-
     void setup_FileMenu_Actions();
     void setup_ActionsMenu_Actions();
     void setup_ViewMenu_Actions();

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -91,7 +91,7 @@ void Properties::loadSettings()
     scrollBarPos = settings.value("ScrollbarPosition", 2).toInt();
     /* default to North. I'd prefer South but North is standard (they say) */
     tabsPos = settings.value("TabsPosition", 0).toInt();
-    alwaysShowTabs = settings.value("AlwaysShowTabs", true).toBool();
+    hideTabBarWithOneTab = settings.value("HideTabBarWithOneTab", false).toBool();
     m_motionAfterPaste = settings.value("MotionAfterPaste", 0).toInt();
 
     /* toggles */
@@ -162,7 +162,7 @@ void Properties::saveSettings()
     settings.setValue("termOpacity", termOpacity);
     settings.setValue("ScrollbarPosition", scrollBarPos);
     settings.setValue("TabsPosition", tabsPos);
-    settings.setValue("AlwaysShowTabs", alwaysShowTabs);
+    settings.setValue("HideTabBarWithOneTab", hideTabBarWithOneTab);
     settings.setValue("MotionAfterPaste", m_motionAfterPaste);
     settings.setValue("Borderless", borderless);
     settings.setValue("TabBarless", tabBarless);

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -200,15 +200,24 @@ void Properties::migrate_settings()
         qDebug() << "Warning: Configuration file was written by a newer version "
                  << "of QTerminal. Some settings might be incompatible";
     }
+
     // Handle renaming of 'Paste Selection' to 'Paste Clipboard' in 0.4.0
     if (lastVersion < "0.4.0")
     {
         settings.beginGroup("Shortcuts");
-        QString tmp = settings.value("Paste Selection", PASTE_CLIPBOARD_SHORTCUT).toString();
-        settings.setValue(PASTE_CLIPBOARD, tmp);
+        QString value = settings.value("Paste Selection", PASTE_CLIPBOARD_SHORTCUT).toString();
+        settings.setValue(PASTE_CLIPBOARD, value);
         settings.remove("Paste Selection");
         settings.endGroup();
     }
+    // Handle renaming of 'AlwaysShowTabs' to 'HideTabBarWithOneTab' after 0.6.0
+    if (lastVersion <= "0.6.0")
+    {
+        QString value = settings.value("AlwaysShowTabs", false).toString();
+        settings.setValue("HideTabBarWithOneTab", value);
+        settings.remove("AlwaysShowTabs");
+    }
+
     if (currentVersion > lastVersion)
         settings.setValue("version", currentVersion);
 }

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -187,3 +187,29 @@ void Properties::saveSettings()
 
 }
 
+void Properties::migrate_settings()
+{
+    // Deal with rearrangements of settings.
+    // If this method becomes unbearably huge we should look at the config-update
+    // system used by kde and razor.
+    QSettings settings;
+    QString lastVersion = settings.value("version", "0.0.0").toString();
+    QString currentVersion = STR_VERSION;
+    if (currentVersion < lastVersion)
+    {
+        qDebug() << "Warning: Configuration file was written by a newer version "
+                 << "of QTerminal. Some settings might be incompatible";
+    }
+    // Handle renaming of 'Paste Selection' to 'Paste Clipboard' in 0.4.0
+    if (lastVersion < "0.4.0")
+    {
+        settings.beginGroup("Shortcuts");
+        QString tmp = settings.value("Paste Selection", PASTE_CLIPBOARD_SHORTCUT).toString();
+        settings.setValue(PASTE_CLIPBOARD, tmp);
+        settings.remove("Paste Selection");
+        settings.endGroup();
+    }
+    if (currentVersion > lastVersion)
+        settings.setValue("version", currentVersion);
+}
+

--- a/src/properties.h
+++ b/src/properties.h
@@ -20,6 +20,8 @@ class Properties
 
         QFont defaultFont();
         void saveSettings();
+        void loadSettings();
+        void migrate_settings();
 
         QByteArray mainWindowGeometry;
         QByteArray mainWindowState;
@@ -67,7 +69,6 @@ class Properties
 
         QMap< QString, QAction * > actions;
 
-        void loadSettings();
 
 
     private:

--- a/src/properties.h
+++ b/src/properties.h
@@ -42,7 +42,7 @@ class Properties
 
         int scrollBarPos;
         int tabsPos;
-        bool alwaysShowTabs;
+        bool hideTabBarWithOneTab;
         int m_motionAfterPaste;
 
         bool borderless;

--- a/src/propertiesdialog.cpp
+++ b/src/propertiesdialog.cpp
@@ -52,7 +52,7 @@ PropertiesDialog::PropertiesDialog(QWidget *parent)
     tabsPos_comboBox->addItems(tabsPosList);
     tabsPos_comboBox->setCurrentIndex(Properties::Instance()->tabsPos);
 
-    alwaysShowTabsCheckBox->setChecked(Properties::Instance()->alwaysShowTabs);
+    hideTabBarCheckBox->setChecked(Properties::Instance()->hideTabBarWithOneTab);
 
     // show main menu bar
     showMenuCheckBox->setChecked(Properties::Instance()->menuVisible);
@@ -139,7 +139,7 @@ void PropertiesDialog::apply()
 
     Properties::Instance()->scrollBarPos = scrollBarPos_comboBox->currentIndex();
     Properties::Instance()->tabsPos = tabsPos_comboBox->currentIndex();
-    Properties::Instance()->alwaysShowTabs = alwaysShowTabsCheckBox->isChecked();
+    Properties::Instance()->hideTabBarWithOneTab = hideTabBarCheckBox->isChecked();
     Properties::Instance()->menuVisible = showMenuCheckBox->isChecked();
     Properties::Instance()->m_motionAfterPaste = motionAfterPasting_comboBox->currentIndex();
 

--- a/src/tabwidget.cpp
+++ b/src/tabwidget.cpp
@@ -413,5 +413,5 @@ void TabWidget::showHideTabBar()
     if (Properties::Instance()->tabBarless)
         tabBar()->setVisible(false);
     else
-        tabBar()->setVisible(Properties::Instance()->alwaysShowTabs || count() > 1);
+        tabBar()->setVisible(!Properties::Instance()->hideTabBarWithOneTab || count() > 1);
 }


### PR DESCRIPTION
Fixes #119 
Also some minor refactoring. Sorry for mixing multiple concerns in a single pull request, but migrating to the new setting needed the version-number problem to be fixed.

Not yet implemented, but a suggestion:
All setting-names are hardcoded in **at least two locations** in the code. I think they should be saved in constants in `Properties`. Do you agree?