### PR TITLE
Update index property of tabs when tabs are moved by drag-and-drop.

### DIFF
--- a/src/tabwidget.cpp
+++ b/src/tabwidget.cpp
@@ -51,6 +51,7 @@ TabWidget::TabWidget(QWidget* parent) : QTabWidget(parent), tabNumerator(0)
     tabBar()->installEventFilter(this);
 
     connect(this, SIGNAL(tabCloseRequested(int)), this, SLOT(removeTab(int)));
+    connect(tabBar(), SIGNAL(tabMoved(int,int)), this, SLOT(updateTabIndices()));
 }
 
 TermWidgetHolder * TabWidget::terminalHolder()
@@ -84,7 +85,7 @@ int TabWidget::addNewTab(const QString & shell_program)
     connect(console, SIGNAL(renameSession()), this, SLOT(renameSession()));
 
     int index = addTab(console, label);
-    recountIndexes();
+    updateTabIndices();
     setCurrentIndex(index);
     console->setInitialFocus();
 
@@ -148,7 +149,7 @@ void TabWidget::zoomReset()
     terminalHolder()->currentTerminal()->impl()->zoomReset();
 }
 
-void TabWidget::recountIndexes()
+void TabWidget::updateTabIndices()
 {
     for(int i = 0; i < count(); i++)
         widget(i)->setProperty(TAB_INDEX_PROPERTY, i);
@@ -210,7 +211,7 @@ void TabWidget::removeFinished()
     if(prop.isValid() && prop.canConvert(QVariant::Int))
     {
         int index = prop.toInt();
-	    removeTab(index);
+        removeTab(index);
 //        if (count() == 0)
 //            emit closeTabNotification();
     }
@@ -224,7 +225,7 @@ void TabWidget::removeTab(int index)
     QTabWidget::removeTab(index);
     w->deleteLater();
 
-    recountIndexes();
+    updateTabIndices();
     int current = currentIndex();
     if (current >= 0 )
     {
@@ -307,7 +308,7 @@ void TabWidget::move(Direction dir)
         setUpdatesEnabled(true);
         setCurrentIndex(newIndex);
         child->setFocus();
-        recountIndexes();
+        updateTabIndices();
     }
 }
 

--- a/src/tabwidget.h
+++ b/src/tabwidget.h
@@ -85,7 +85,6 @@ signals:
 protected:
     enum Direction{Left = 1, Right};
     void contextMenuEvent(QContextMenuEvent * event);
-    void recountIndexes();
     void move(Direction);
     /*! Event filter for TabWidget's QTabBar. It's installed on tabBar()
         in the constructor.
@@ -93,6 +92,8 @@ protected:
         renaming or new tab opening
      */
     bool eventFilter(QObject *obj, QEvent *event);
+protected slots:
+    void updateTabIndices();
 
 private:
     int tabNumerator;


### PR DESCRIPTION
Fixes #127

When a tab is closed because the contained terminal finisched, the TAB_INDEX_PROPERTY is used to  determine the index of the tab. This property was not updated when the user reordered the tabs by drag-and-drop.

I also renamed 'recountIndexes()' to 'updateTabIndices()' to make its intent more clear.