### PR TITLE
add save geometry on exit

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -60,10 +60,11 @@
 
 #define HIDE_WINDOW_BORDERS "Hide Window Borders"
 #define SHOW_TAB_BAR "Show Tab Bar"
+#define FULLSCREEN "Fullscreen"
 
 /* Some defaults for QTerminal application */
 
-#define DEFAULT_WIDTH                  800
+#define DEFAULT_WIDTH                  1000
 #define DEFAULT_HEIGHT                 600
 #define DEFAULT_FONT                   "Monospace"
 
@@ -104,6 +105,8 @@
 #define MOVE_RIGHT_SHORTCUT            "Shift+Alt+Right"
 
 #define RENAME_SESSION_SHORTCUT        "Shift+Alt+S"
+
+#define FULLSCREEN_SHORTCUT "F11"
 
 // XON/XOFF features:
 

--- a/src/forms/propertiesdialog.ui
+++ b/src/forms/propertiesdialog.ui
@@ -364,7 +364,7 @@
             </property>
            </widget>
           </item>
-          <item row="6" column="1">
+          <item row="7" column="1">
            <spacer name="verticalSpacer_4">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
@@ -377,17 +377,24 @@
             </property>
            </spacer>
           </item>
-          <item row="5" column="0" colspan="3">
+          <item row="6" column="0" colspan="3">
            <widget class="QCheckBox" name="useCwdCheckBox">
             <property name="text">
              <string>Open new terminals in current working directory</string>
             </property>
            </widget>
           </item>
-          <item row="4" column="0" colspan="3">
-           <widget class="QCheckBox" name="saveGeomOnExitCheckBox">
+          <item row="5" column="0" colspan="3">
+           <widget class="QCheckBox" name="saveSizeOnExitCheckBox">
             <property name="text">
-             <string>Save Geometry when closing</string>
+             <string>Save Size when closing</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0" colspan="3">
+           <widget class="QCheckBox" name="savePosOnExitCheckBox">
+            <property name="text">
+             <string>Save Position when closing</string>
             </property>
            </widget>
           </item>

--- a/src/forms/propertiesdialog.ui
+++ b/src/forms/propertiesdialog.ui
@@ -364,7 +364,7 @@
             </property>
            </widget>
           </item>
-          <item row="5" column="1">
+          <item row="6" column="1">
            <spacer name="verticalSpacer_4">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
@@ -377,10 +377,17 @@
             </property>
            </spacer>
           </item>
-          <item row="4" column="0" colspan="3">
+          <item row="5" column="0" colspan="3">
            <widget class="QCheckBox" name="useCwdCheckBox">
             <property name="text">
              <string>Open new terminals in current working directory</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0" colspan="3">
+           <widget class="QCheckBox" name="saveGeomOnExitCheckBox">
+            <property name="text">
+             <string>Save Geometry when closing</string>
             </property>
            </widget>
           </item>

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -486,7 +486,10 @@ void MainWindow::closeEvent(QCloseEvent *ev)
         // #80 - do not save state and geometry in drop mode
         if (!m_dropMode)
         {
-            Properties::Instance()->mainWindowGeometry = saveGeometry();
+	    if (Properties::Instance()->saveGeomOnExit)
+	    {
+            	Properties::Instance()->mainWindowGeometry = saveGeometry();
+	    }
             Properties::Instance()->mainWindowState = saveState();
         }
         Properties::Instance()->saveSettings();

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -78,6 +78,7 @@ private slots:
     void toggleTabBar();
     void toggleMenu();
 
+    void showFullscreen();
     void showHide();
     void setKeepOpen(bool value);
     void find();

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -64,7 +64,8 @@ void Properties::loadSettings()
     }
     settings.endGroup();
 
-    mainWindowGeometry = settings.value("MainWindow/geometry").toByteArray();
+    mainWindowSize = settings.value("MainWindow/size").toSize();
+    mainWindowPosition = settings.value("MainWindow/pos").toPoint();
     mainWindowState = settings.value("MainWindow/state").toByteArray();
 
     historyLimited = settings.value("HistoryLimited", true).toBool();
@@ -99,7 +100,8 @@ void Properties::loadSettings()
     tabBarless = settings.value("TabBarless", false).toBool();
     menuVisible = settings.value("MenuVisible", true).toBool();
     askOnExit = settings.value("AskOnExit", true).toBool();
-    saveGeomOnExit = settings.value("SaveGeomOnExit", true).toBool();
+    saveSizeOnExit = settings.value("SaveSizeOnExit", true).toBool();
+    savePosOnExit = settings.value("SavePosOnExit", true).toBool();
     useCWD = settings.value("UseCWD", false).toBool();
 
     // bookmarks
@@ -137,7 +139,8 @@ void Properties::saveSettings()
     }
     settings.endGroup();
 
-    settings.setValue("MainWindow/geometry", mainWindowGeometry);
+    settings.setValue("MainWindow/size", mainWindowSize);
+    settings.setValue("MainWindow/pos", mainWindowPosition);
     settings.setValue("MainWindow/state", mainWindowState);
 
     settings.setValue("HistoryLimited", historyLimited);
@@ -169,7 +172,8 @@ void Properties::saveSettings()
     settings.setValue("TabBarless", tabBarless);
     settings.setValue("MenuVisible", menuVisible);
     settings.setValue("AskOnExit", askOnExit);
-    settings.setValue("SaveGeomOnExit", saveGeomOnExit);
+    settings.setValue("SavePosOnExit", savePosOnExit);
+    settings.setValue("SaveSizeOnExit", saveSizeOnExit);
     settings.setValue("UseCWD", useCWD);
 
     // bookmarks

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -99,6 +99,7 @@ void Properties::loadSettings()
     tabBarless = settings.value("TabBarless", false).toBool();
     menuVisible = settings.value("MenuVisible", true).toBool();
     askOnExit = settings.value("AskOnExit", true).toBool();
+    saveGeomOnExit = settings.value("SaveGeomOnExit", true).toBool();
     useCWD = settings.value("UseCWD", false).toBool();
 
     // bookmarks
@@ -168,6 +169,7 @@ void Properties::saveSettings()
     settings.setValue("TabBarless", tabBarless);
     settings.setValue("MenuVisible", menuVisible);
     settings.setValue("AskOnExit", askOnExit);
+    settings.setValue("SaveGeomOnExit", saveGeomOnExit);
     settings.setValue("UseCWD", useCWD);
 
     // bookmarks

--- a/src/properties.h
+++ b/src/properties.h
@@ -23,7 +23,8 @@ class Properties
         void loadSettings();
         void migrate_settings();
 
-        QByteArray mainWindowGeometry;
+        QSize mainWindowSize;
+        QPoint mainWindowPosition;
         QByteArray mainWindowState;
         //ShortcutMap shortcuts;
         QString shell;
@@ -53,7 +54,8 @@ class Properties
 
         bool askOnExit;
 
-        bool saveGeomOnExit;
+        bool saveSizeOnExit;
+        bool savePosOnExit;
 
         bool useCWD;
 

--- a/src/properties.h
+++ b/src/properties.h
@@ -53,6 +53,8 @@ class Properties
 
         bool askOnExit;
 
+        bool saveGeomOnExit;
+
         bool useCWD;
 
         bool useBookmarks;

--- a/src/propertiesdialog.cpp
+++ b/src/propertiesdialog.cpp
@@ -82,6 +82,8 @@ PropertiesDialog::PropertiesDialog(QWidget *parent)
 
     askOnExitCheckBox->setChecked(Properties::Instance()->askOnExit);
 
+    saveGeomOnExitCheckBox->setChecked(Properties::Instance()->saveGeomOnExit);
+
     useCwdCheckBox->setChecked(Properties::Instance()->useCWD);
 
     historyLimited->setChecked(Properties::Instance()->historyLimited);
@@ -132,6 +134,8 @@ void PropertiesDialog::apply()
     Properties::Instance()->highlightCurrentTerminal = highlightCurrentCheckBox->isChecked();
 
     Properties::Instance()->askOnExit = askOnExitCheckBox->isChecked();
+
+    Properties::Instance()->saveGeomOnExit = saveGeomOnExitCheckBox->isChecked();
 
     Properties::Instance()->useCWD = useCwdCheckBox->isChecked();
 

--- a/src/propertiesdialog.cpp
+++ b/src/propertiesdialog.cpp
@@ -82,7 +82,8 @@ PropertiesDialog::PropertiesDialog(QWidget *parent)
 
     askOnExitCheckBox->setChecked(Properties::Instance()->askOnExit);
 
-    saveGeomOnExitCheckBox->setChecked(Properties::Instance()->saveGeomOnExit);
+    savePosOnExitCheckBox->setChecked(Properties::Instance()->savePosOnExit);
+    saveSizeOnExitCheckBox->setChecked(Properties::Instance()->saveSizeOnExit);
 
     useCwdCheckBox->setChecked(Properties::Instance()->useCWD);
 
@@ -135,7 +136,8 @@ void PropertiesDialog::apply()
 
     Properties::Instance()->askOnExit = askOnExitCheckBox->isChecked();
 
-    Properties::Instance()->saveGeomOnExit = saveGeomOnExitCheckBox->isChecked();
+    Properties::Instance()->savePosOnExit = savePosOnExitCheckBox->isChecked();
+    Properties::Instance()->saveSizeOnExit = saveSizeOnExitCheckBox->isChecked();
 
     Properties::Instance()->useCWD = useCwdCheckBox->isChecked();
 


### PR DESCRIPTION
when qterminal is closed, it will save geometry. problem is, for people who use several instances, every new window will exactly overlap old ones. Adding an option to save geometry on exit let the WM (openbox for example) puts the new windows where it wants.