### PR TITLE
make only terminal widget transparent, not the parent window

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -46,6 +46,8 @@ MainWindow::MainWindow(const QString& work_dir,
       m_dropLockButton(0),
       m_dropMode(dropMode)
 {
+    setAttribute(Qt::WA_TranslucentBackground);
+
     setupUi(this);
     Properties::Instance()->migrate_settings();
     Properties::Instance()->loadSettings();
@@ -80,6 +82,7 @@ MainWindow::MainWindow(const QString& work_dir,
         restoreState(Properties::Instance()->mainWindowState);
     }
 
+    consoleTabulator->setAutoFillBackground(true);
     connect(consoleTabulator, SIGNAL(closeTabNotification()), SLOT(close()));
     consoleTabulator->setWorkDirectory(work_dir);
     consoleTabulator->setTabPosition((QTabWidget::TabPosition)Properties::Instance()->tabsPos);


### PR DESCRIPTION
Closes issue #163.

The attribute Qt::WA_translucentBackground applies only to top-level widgets (main windows) and makes every child widget transparent, unless AutoFillBackground is set or the child explicitly draws it's background.

This allows to control the terminal widget's transparency, while the window frame stays fully opaque. Unfortunately this is not valid vice versa. Meaning: If you change window transparency, it also affects the terminal transparency.

Anyway, this is far better than before.

Screenshot:

![qterminal-semi-transparent](https://cloud.githubusercontent.com/assets/440517/9288367/862582d2-4343-11e5-8a97-7724af65aab2.png)
